### PR TITLE
Fix `cmap` in `nx.draw` used without `node_colors`

### DIFF
--- a/graph_coloring.py
+++ b/graph_coloring.py
@@ -30,7 +30,7 @@ def build_graph(num_nodes):
 
     G = nx.powerlaw_cluster_graph(num_nodes, 3, 0.4)
     pos = nx.spring_layout(G)
-    nx.draw(G, pos=pos, node_size=50, edgecolors='k', cmap='hsv')
+    nx.draw(G, pos=pos, node_size=50, edgecolors='k')
     plt.savefig("original_graph.png")
 
     return G, pos


### PR DESCRIPTION
Fixes a `UserWarning` raising during graph build (i.e. tests):
```
/path/to/networkx/drawing/nx_pylab.py:437: UserWarning: No data for colormapping provided via 'c'. Parameters 'cmap' will be ignored
  node_collection = ax.scatter(
```